### PR TITLE
Added support for getting input and output schemas in table and ce components

### DIFF
--- a/packages/jdm-editor/package.json
+++ b/packages/jdm-editor/package.json
@@ -21,7 +21,8 @@
     "build:watch": "vite build --watch",
     "storybook": "storybook dev -p 9009",
     "build:storybook": "storybook build -o docs",
-    "prepublishOnly": "vite build"
+    "prepublishOnly": "vite build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@ant-design/icons": "5.3.7",
@@ -30,8 +31,8 @@
     "@codemirror/lint": "^6.8.1",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",
-    "@gorules/lezer-zen": "workspace:*",
-    "@gorules/lezer-zen-template": "workspace:*",
+    "@gorules/lezer-zen": "0.4.0",
+    "@gorules/lezer-zen-template": "0.2.0",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/packages/jdm-editor/src/components/code-editor/ce.tsx
+++ b/packages/jdm-editor/src/components/code-editor/ce.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import React, { useEffect, useMemo, useRef } from 'react';
 
 import { composeRefs } from '../../helpers/compose-refs';
+import { useDecisionGraphState } from '../decision-graph';
 import './ce.scss';
 import { zenExtensions, zenHighlightDark, zenHighlightLight } from './extensions/zen';
 
@@ -60,6 +61,11 @@ export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
     const codeMirror = useRef<EditorView>(null);
     const { token } = theme.useToken();
 
+    const { inputsSchema, outputsSchema } = useDecisionGraphState(
+      ({ inputsSchema = [], outputsSchema = [] }) => ({ inputsSchema, outputsSchema }),
+    );
+    const schema = [...inputsSchema, ...outputsSchema];
+
     const compartment = useMemo(
       () => ({
         zenExtension: new Compartment(),
@@ -84,7 +90,7 @@ export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
           extensions: [
             EditorView.lineWrapping,
             bracketMatching(),
-            compartment.zenExtension.of(zenExtensions({ type })),
+            compartment.zenExtension.of(zenExtensions({ type, schema })),
             compartment.updateListener.of(updateListener(onChange, onStateChange)),
             compartment.theme.of(editorTheme(token.mode === 'dark')),
             compartment.placeholder.of(placeholder ? placeholderExt(placeholder) : []),
@@ -167,9 +173,9 @@ export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
       }
 
       codeMirror.current.dispatch({
-        effects: compartment.zenExtension.reconfigure(zenExtensions({ type })),
+        effects: compartment.zenExtension.reconfigure(zenExtensions({ type, schema })),
       });
-    }, [type]);
+    }, [type, schema]);
 
     useEffect(() => {
       if (!codeMirror.current) {

--- a/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/context/dg-store.context.tsx
@@ -7,6 +7,7 @@ import type { EdgeChange, NodeChange, ReactFlowInstance, useEdgesState, useNodes
 import type { StoreApi, UseBoundStore } from 'zustand';
 import { create } from 'zustand';
 
+import { SchemaSelectProps } from '../../../helpers/components';
 import type { CodeEditorProps } from '../../code-editor';
 import { mapToGraphEdge, mapToGraphEdges, mapToGraphNode, mapToGraphNodes } from '../dg-util';
 import type { useGraphClipboard } from '../hooks/use-graph-clipboard';
@@ -71,6 +72,9 @@ export type DecisionGraphStoreType = {
     panels?: PanelType[];
     activePanel?: string;
     onPanelsChange?: (val?: string) => void;
+
+    inputsSchema?: SchemaSelectProps[];
+    outputsSchema?: SchemaSelectProps[];
 
     simulate?: Simulation;
 

--- a/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/dg-empty.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useEffect, useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
+import type { SchemaSelectProps } from '../../../src/helpers/components';
 import {
   type DecisionGraphStoreType,
   type DecisionGraphType,
@@ -28,6 +29,9 @@ export type DecisionGraphEmptyType = {
   panels?: DecisionGraphStoreType['state']['panels'];
   onPanelsChange?: DecisionGraphStoreType['listeners']['onPanelsChange'];
 
+  inputsSchema?: SchemaSelectProps[];
+  outputsSchema?: SchemaSelectProps[];
+
   simulate?: DecisionGraphStoreType['state']['simulate'];
 
   onChange?: DecisionGraphStoreType['listeners']['onChange'];
@@ -50,6 +54,8 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
   defaultActivePanel,
   panels,
   simulate,
+  inputsSchema,
+  outputsSchema,
   onPanelsChange,
   onReactFlowInit,
   onCodeExtension,
@@ -80,6 +86,13 @@ export const DecisionGraphEmpty: React.FC<DecisionGraphEmptyType> = ({
   useEffect(() => {
     stateStore.setState({ name: name ?? 'graph.json' });
   }, [name]);
+
+  useEffect(() => {
+    stateStore.setState({
+      inputsSchema,
+      outputsSchema
+    });
+  }, [inputsSchema, outputsSchema]);
 
   useEffect(() => {
     stateStore.setState({

--- a/packages/jdm-editor/src/components/decision-graph/graph/tab-decision-table.tsx
+++ b/packages/jdm-editor/src/components/decision-graph/graph/tab-decision-table.tsx
@@ -13,14 +13,16 @@ export type TabDecisionTableProps = {
 
 export const TabDecisionTable: React.FC<TabDecisionTableProps> = ({ id, manager }) => {
   const graphActions = useDecisionGraphActions();
-  const { nodeTrace, disabled, configurable, content } = useDecisionGraphState(
-    ({ simulate, disabled, configurable, decisionGraph }) => ({
+  const { nodeTrace, disabled, configurable, content, inputsSchema, outputsSchema } = useDecisionGraphState(
+    ({ simulate, disabled, configurable, decisionGraph, inputsSchema, outputsSchema }) => ({
       nodeTrace: match(simulate)
         .with({ result: P._ }, ({ result }) => result?.trace?.[id] as SimulationTrace<SimulationTraceDataTable>)
         .otherwise(() => null),
       disabled,
       configurable,
       content: (decisionGraph?.nodes ?? []).find((node) => node.id === id)?.content,
+      inputsSchema,
+      outputsSchema,
     }),
   );
 
@@ -45,6 +47,8 @@ export const TabDecisionTable: React.FC<TabDecisionTableProps> = ({ id, manager 
       disabled={disabled}
       configurable={configurable}
       activeRules={(activeRules || []).filter((id) => !!id)}
+      inputsSchema={inputsSchema}
+      outputsSchema={outputsSchema}
     />
   );
 };


### PR DESCRIPTION
- [x] Added support for getting input and output schemas from the decision graph
- [x] Passes input and output schemas to tables as possible inputs or outputs
- [x] Passes input and output schemas to code editors as possible suggestions